### PR TITLE
workaround: rsync processes quitting early at the start

### DIFF
--- a/parsyncfp
+++ b/parsyncfp
@@ -4,7 +4,7 @@ use Getopt::Long;      # for std option handling: -h --yadda=badda, etc
 use Socket;
 use Env qw(HOME PATH);
 use File::Path qw(remove_tree);
-
+use Time::HiRes qw(sleep);
 
 # after significant changes, update the tarball and cp to moo for distribution; update the github
 # fn="/home/hjm/bin/parsyncfp"; cd ; cp  $fn ~/parsyncfp/; tar -cvzf parsyncfp+utils.tar.gz parsyncfp; scp parsyncfp+utils.tar.gz moo:~/public_html/parsync ; 
@@ -318,6 +318,7 @@ while ($RSYNCS_GOING < $NP && $KEEPGOING) { #
     # ie LOTS. but they can be deleted after the run has been verified..
     # TODO don't know if we need this logfile.
     if ($DEBUG) {&debug(__LINE__, "Complete rsync cmd = [$RSYNC_CMD]");}
+    sleep(rand(1.0));
     system("$RSYNC_CMD"); # launch rsync and capture the bg job PID to PIDfile
     $CUR_FPI++;
     $RSYNCS_GOING++;


### PR DESCRIPTION
Parsyncfp is really a great tool! I have been trying to run it with high NP (64-128 and higher) and I noticed an issue that some of rsync processes often quit early at the start. 

The issue seems to be limited to the initial rsync processes, so I think it may be caused by a large number of connections being opened with the remote SSH server at the same time. I have added a short, random delay before each process starts and so far I do not get those errors any more.

Please, would you accept adding this workaround to the master branch?