### PR TITLE
Fix fast fpart runs with forced rsync polling

### DIFF
--- a/parsyncfp
+++ b/parsyncfp
@@ -393,6 +393,8 @@ if ($VERBOSE == 0) { #  ..............|---------- / ---------|
 
 my $start_secs = `date  +"%s"`; 
 
+$STILLRSYNCS=1;
+
 while ($CUR_FPI < $NBR_FP_FLES || $FP_RUNNING || $STILLRSYNCS ) {
   $rPIDs = "";
   # print the header


### PR DESCRIPTION
Explicitly initialize STILLRSYNCS=1 to handle case where dirs are
small and fpart is finished running before the rsync polling loop
starts.  This forces the polling loop to enter.