### PR TITLE
Fix the listing of all rsync PIDs on the system. Fixes #24

### DIFF
--- a/parsyncfp
+++ b/parsyncfp
@@ -665,7 +665,7 @@ sub get_rPIDs($$) {
   # how many rsyncs are running?  Check the PIDFILE against the rsync PIDs that are running
   # if there are other rsyncs running, their PIDs won't be in the PIDFILE.
   # so have to do a diff of the PIDFILE vs all PIDs of rsyncs running.
-  my $ALL_SYS_RSYNC_PIDS = `ps aux | grep rsyn[c] |  awk '{print $2}' | sort -g | tr '\n' ' '`;  chop $ALL_SYS_RSYNC_PIDS;
+  my $ALL_SYS_RSYNC_PIDS = `ps aux | grep rsyn[c] |  awk '{print \$2}' | sort -g | tr '\n' ' '`;  chop $ALL_SYS_RSYNC_PIDS;
   if ($DEBUG){print "\tDEBUG: PIDs of all rsync procs on the system: " . $ALL_SYS_RSYNC_PIDS . " \n"}
   $NASRP = @ASRP = split(/\s+/, $ALL_SYS_RSYNC_PIDS);
   open (PIDFILE, "<$pidfile") or FATAL("Can't open PIDFILE [$pidfile]'");

--- a/parsyncfp
+++ b/parsyncfp
@@ -666,6 +666,7 @@ sub get_rPIDs($$) {
   # if there are other rsyncs running, their PIDs won't be in the PIDFILE.
   # so have to do a diff of the PIDFILE vs all PIDs of rsyncs running.
   my $ALL_SYS_RSYNC_PIDS = `ps aux | grep rsyn[c] |  awk '{print $2}' | sort -g | tr '\n' ' '`;  chop $ALL_SYS_RSYNC_PIDS;
+  if ($DEBUG){print "\tDEBUG: PIDs of all rsync procs on the system: " . $ALL_SYS_RSYNC_PIDS . " \n"}
   $NASRP = @ASRP = split(/\s+/, $ALL_SYS_RSYNC_PIDS);
   open (PIDFILE, "<$pidfile") or FATAL("Can't open PIDFILE [$pidfile]'");
   # PIDs from the PIDFILE to compare system rsyncs (could be multiple going)


### PR DESCRIPTION
This is a fix for issue #24.

The argument '$2' for the awk command need to be escaped as '\$2' to correctly reach the awk process (just like it's also done multiple other places in the script).

To show the problem and the result of the suggested fix, I have added a debug statement as well (feel free to cut that out if you like). This debug statement says:

Before the fix was applied:
`DEBUG: PIDs of all rsync procs on the system: efam-da+ 28824  0.4  0.0  27972  9592 ?        Ss   12:31   0:00 perl /home/mb/git/parsyncfp/parsyncfp -NP=3 --rsyncopts=--partial -v --info=BACKUP,FLIST0,STATS0 --maxbw=19200 --chunksize=2G --debug --verbose=2 --nowait --startdir=/home/mb/data . serv2:/tmp/dest jph      17682  0.0  0.0  23556  2932 ?        Ss   Jun17   0:00 rsync --server -vulogDtprze.iLsfx . /home/jph/data/ jph      17683  0.1  0.0  23816  1688 ?        S    Jun17   1:54 rsync --server -vulogDtprze.iLsfx . /home/jph/data2/ miba     25650  0.0  0.0  53940  8584 pts/0    S+   12:29   0:00 vi parsyncfp/parsyncfp root     10517 44.3  0.1 209784 141996 ?       R    Jun17 469:24 /usr/bin/rsync --daemon --no-detach root     13644  0.0  0.0   4504   736 ?        S    12:18   0:00 sh -c timeout 86400 rsync -avz -y --delete-during --stats --numeric-ids --partial   serv3:/tmp/tmp_rsync/ /tmp/data3/ 2>&1 | tee /tmp/rsync-FQdta root     13645  0.0  0.0  11556   828 ?        S    12:18   0:00 timeout 86400 rsync -avz -y --delete-during --stats --numeric-ids --partial serv3:/tmp_rsync3/ /tmp/data4/ root     13646  0.0  0.0   7296   668 ?        S    12:18   0:00 tee /tmp/virtual_envs-live-rsync-gazelle-live_rsync-FQdta 
`

After the fix was applied:
`
DEBUG: PIDs of all rsync procs on the system: 820 1947 1949 1958 1960 1969 1971 10517 13644 13645 13646 13647 13696 17682 17683 27954 31608
`