### PR TITLE
Add fpart Github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The suspend/unsuspend bugs (there were actually 2) have been squashed (I think).
 
 parsyncfp (pfp) is the offspring of my [parsync](https://github.com/hjmangalam/parsync) 
  ([more info here](http://moo.nac.uci.edu/~hjm/parsync/))
- and Ganael LaPlanche's [fpart](http://goo.gl/K1WwtD), which
+ and Ganael LaPlanche's fpart [1](https://github.com/martymac/fpart) [2](https://goo.gl/K1WwtD), which
 collects files based on size or number into chunkfiles which can be fed to rsync on a 
 chunk by chunk basis.  This allows pfp to begin transferring files before the 
 complete recursive descent of the source dir is complete.  This feature can save many 


### PR DESCRIPTION
Hi hjmangalam,

First off, thank you SO MUCH for developing and maintaining parsyncfp!  I love this tool.  Stumbled upon parsync last year when I needed to transfer over a hundred million files.  Parsync actually worked well enough last April, however when I came back a few weeks ago and tried parsyncfp: WOW! It's even nicer and easier to use than the previous incantation! (beautiful and clean console output).  Seriously, thank you!!!

This is just a minor update to the README to add a direct link to MartyMac's fpart repository here on GitHub.

    commit 83a1b69171757ccd4c82249b0ad8af94580945a4 (HEAD -> jay/readme-fpart, origin/jay/readme-fpart)
    Author: Jay Taylor <jay.taylor@oracle.com>
    Date:   Mon Apr 6 13:03:45 2020 -0700
    
        Added fpart Github link.
        
        minor: Also switch goo.gl link to use HTTPS.
    

Best wishes,
Jay